### PR TITLE
chore: add github project automation scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report something that isn’t working as expected
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+### Description
+<!-- What went wrong? -->
+
+### Steps to Reproduce
+1.
+2.
+3.
+
+### Expected Behavior
+<!-- What should have happened? -->
+
+### Screenshots / Logs
+<!-- Attach relevant info -->
+
+### Environment
+- App Version:
+- Device & OS:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: LACOSA PRD
+    url: https://github.com/<YOUR_ORG_OR_USER>/<YOUR_REPO>/blob/main/LACOSA_PRD.md
+    about: Read the product spec before filing a new issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for LACOSA
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+### Related Section in PRD
+<!-- Paste the heading or link from LACOSA_PRD.md -->
+
+### Problem / User Need
+<!-- What user problem are we solving? -->
+
+### Proposed Solution
+<!-- Feature summary, user flows, UI notes -->
+
+### Acceptance Criteria
+- [ ] Behavior is clear and testable
+- [ ] Works on iOS and Android
+- [ ] Basic analytics events added (open, success)
+
+### Dependencies / References
+<!-- Mockups, APIs, data sources -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+<!-- What does this PR change? Link to issues. -->
+
+## Screenshots / Demos
+<!-- Optional -->
+
+## Checklist
+- [ ] PR title follows conventional commits (e.g., feat:, fix:, chore:)
+- [ ] Tests or manual verification steps included
+- [ ] Updates docs / PRD links if needed
+- [ ] Added appropriate labels (bug, enhancement, ui/ux, data, AI, priority)

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+name: Add to Roadmap Project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to project
+        uses: actions/add-to-project@v1
+        with:
+          # TODO: replace with your real org/user and project number
+          project-url: https://github.com/orgs/<YOUR_ORG>/projects/<PROJECT_NUMBER>
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,0 +1,183 @@
+name: Project Status Sync
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled, reopened, closed]
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, reopened, closed]
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+      projects: write
+    env:
+      # TODO: set these in the 'env' block or as repository secrets.
+      ORG: <YOUR_ORG>                      # e.g., dmrl789
+      PROJECT_NUMBER: <PROJECT_NUMBER>     # e.g., 1
+      STATUS_FIELD_NAME: Status            # Must match your project's field
+      READY_LABEL: "priority: high"
+      IN_PROGRESS_LABEL: "in progress"
+      REVIEW_LABEL: "review"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup gh
+        uses: cli/cli-action@v2
+        with:
+          version: stable
+
+      - name: Set GH_TOKEN
+        run: echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Determine item type and desired status
+        id: decide
+        run: |
+          TYPE="${{ github.event_name }}"
+          LABELS=$(jq -r '.issue.labels[].name? // empty' <<< '${{ toJson(github.event.issue) }}')
+          # Default
+          STATUS="Backlog"
+
+          # Map labels -> statuses
+          if echo "$LABELS" | grep -iq "${READY_LABEL}"; then
+            STATUS="Ready"
+          fi
+          if echo "$LABELS" | grep -iq "${IN_PROGRESS_LABEL}"; then
+            STATUS="In Progress"
+          fi
+          if echo "$LABELS" | grep -iq "${REVIEW_LABEL}"; then
+            STATUS="Review"
+          fi
+          if [ "${{ github.event.action }}" = "closed" ]; then
+            STATUS="Done"
+          fi
+
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - name: Get project and field IDs
+        id: ids
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ env.ORG }}
+          PROJECT_NUMBER: ${{ env.PROJECT_NUMBER }}
+          STATUS_FIELD_NAME: ${{ env.STATUS_FIELD_NAME }}
+        run: |
+          PROJECT_ID=$(gh api graphql -f query='
+            query($org:String!,$number:Int!){
+              organization(login:$org){
+                projectV2(number:$number){ id, fields(first:50){ nodes{ ... on ProjectV2FieldCommon { id name } ... on ProjectV2SingleSelectField { id name options { id name } } } } }
+              }
+            }' -F org="$ORG" -F number="$PROJECT_NUMBER" --jq '.data.organization.projectV2.id')
+
+          STATUS_FIELD_ID=$(gh api graphql -f query='
+            query($org:String!,$number:Int!,$name:String!){
+              organization(login:$org){
+                projectV2(number:$number){
+                  fields(first:50){
+                    nodes{
+                      ... on ProjectV2SingleSelectField { id name options { id name } }
+                    }
+                  }
+                }
+              }
+            }' -F org="$ORG" -F number="$PROJECT_NUMBER" -F name="$STATUS_FIELD_NAME" --jq \
+            ".data.organization.projectV2.fields.nodes[] | select(.name==\"$STATUS_FIELD_NAME\") | .id")
+
+          echo "project_id=$PROJECT_ID" >> $GITHUB_OUTPUT
+          echo "status_field_id=$STATUS_FIELD_ID" >> $GITHUB_OUTPUT
+
+      - name: Resolve status option ID
+        id: status_opt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ env.ORG }}
+          PROJECT_NUMBER: ${{ env.PROJECT_NUMBER }}
+          STATUS_FIELD_NAME: ${{ env.STATUS_FIELD_NAME }}
+          DESIRED_STATUS: ${{ steps.decide.outputs.status }}
+        run: |
+          STATUS_OPTION_ID=$(gh api graphql -f query='
+            query($org:String!,$number:Int!,$name:String!){
+              organization(login:$org){
+                projectV2(number:$number){
+                  fields(first:50){
+                    nodes{
+                      ... on ProjectV2SingleSelectField {
+                        name
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -F org="$ORG" -F number="$PROJECT_NUMBER" -F name="$STATUS_FIELD_NAME" --jq \
+            ".data.organization.projectV2.fields.nodes[] | select(.name==\"$STATUS_FIELD_NAME\") | .options[] | select(.name==\"$DESIRED_STATUS\") | .id")
+
+          if [ -z "$STATUS_OPTION_ID" ]; then
+            echo "Status option '$DESIRED_STATUS' not found. Ensure your project has options: Backlog, Ready, In Progress, Review, Done."
+            exit 1
+          fi
+
+          echo "status_option_id=$STATUS_OPTION_ID" >> $GITHUB_OUTPUT
+
+      - name: Ensure item is in project, then set Status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_ID: ${{ steps.ids.outputs.project_id }}
+          STATUS_FIELD_ID: ${{ steps.ids.outputs.status_field_id }}
+          STATUS_OPTION_ID: ${{ steps.status_opt.outputs.status_option_id }}
+        run: |
+          # Determine content node id (issue or PR)
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            CONTENT_ID=$(gh api graphql -f query='
+              query($owner:String!,$repo:String!,$number:Int!){
+                repository(owner:$owner,name:$repo){ issue(number:$number){ id } }
+              }' -F owner='${{ github.repository_owner }}' -F repo='${{ github.event.repository.name }}' -F number='${{ github.event.issue.number }}' --jq '.data.repository.issue.id')
+          else
+            CONTENT_ID=$(gh api graphql -f query='
+              query($owner:String!,$repo:String!,$number:Int!){
+                repository(owner:$owner,name:$repo){ pullRequest(number:$number){ id } }
+              }' -F owner='${{ github.repository_owner }}' -F repo='${{ github.event.repository.name }}' -F number='${{ github.event.pull_request.number }}' --jq '.data.repository.pullRequest.id')
+          fi
+
+          # Add to project (if not already)
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($project:ID!,$content:ID!){
+              addProjectV2ItemById(input:{projectId:$project, contentId:$content}){ item { id } }
+            }' -F project="$PROJECT_ID" -F content="$CONTENT_ID" --jq '.data.addProjectV2ItemById.item.id' || true)
+
+          # If already present, fetch item id
+          if [ -z "$ITEM_ID" ]; then
+            ITEM_ID=$(gh api graphql -f query='
+              query($project:ID!,$content:ID!){
+                node(id:$project){
+                  ... on ProjectV2 {
+                    items(first:100, query:""){
+                      nodes{
+                        id
+                        content { ... on Issue { id } ... on PullRequest { id } }
+                      }
+                    }
+                  }
+                }
+              }' -F project="$PROJECT_ID" --jq \
+              '.data.node.items.nodes[] | select(.content.id=="'"$CONTENT_ID"'") | .id')
+          fi
+
+          # Set Status field
+          gh api graphql -f query='
+            mutation($project:ID!,$item:ID!,$field:ID!,$option: String!){
+              updateProjectV2ItemFieldValue(input:{
+                projectId:$project,
+                itemId:$item,
+                fieldId:$field,
+                value:{ singleSelectOptionId:$option }
+              }){ clientMutationId }
+            }' \
+            -F project="$PROJECT_ID" \
+            -F item="$ITEM_ID" \
+            -F field="$STATUS_FIELD_ID" \
+            -F option="$STATUS_OPTION_ID"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,20 @@
+name: Sync Labels
+
+on:
+  push:
+    paths:
+      - labels.yml
+      - .github/workflows/sync-labels.yml
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: labels.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/labels.yml
+++ b/labels.yml
@@ -1,0 +1,36 @@
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or improvement
+- name: bug
+  color: "d73a4a"
+  description: Something isn't working
+- name: ui/ux
+  color: "c5def5"
+  description: Design or usability
+- name: data
+  color: "bfdadc"
+  description: Data ingestion, scraping, pipelines
+- name: AI
+  color: "5319e7"
+  description: LLM, RAG, prompts, moderation
+- name: good first issue
+  color: "7057ff"
+  description: Starter-friendly task
+- name: priority: high
+  color: "b60205"
+  description: Critical for MVP
+- name: priority: medium
+  color: "fbca04"
+  description: Important but not blocking
+- name: priority: low
+  color: "0e8a16"
+  description: Nice-to-have
+- name: docs
+  color: "0075ca"
+  description: Documentation updates
+- name: in progress
+  color: "1d76db"
+  description: Work has started
+- name: review
+  color: "c2e0c6"
+  description: Needs code/design review


### PR DESCRIPTION
## Summary
- add issue and pull request templates tailored for LACOSA
- define repository labels and workflow to sync them automatically
- add automation to enroll issues/PRs into the roadmap project and update status via labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c1a50f14832bb1e475b7b825b921