### PR TITLE
Add lifestyle venues endpoint and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ requirements.txt  # Python dependencies
 | Housing & Rentals | `GET /api/housing/rentals` | Filterable rental listings with verification flags. |
 | Schools Directory | `GET /api/schools/directory` | Curriculum- and level-based lookup for schools. |
 | Food & Lifestyle | `GET /api/shopping/essentials` | Curated essentials (pharmacies, electronics). |
+| Cafés & Nightlife | `GET /api/lifestyle/venues` | Filterable list of cafés, restaurants, and bars with expat-friendly tags. |
 | Markets & Deliveries | `GET /api/shopping/markets` | Market schedules plus delivery partners. |
 | Arts & Culture | `GET /api/culture/events` | Upcoming events with AI summaries. |
 | Transport | `GET /api/transport/options` | Trusted transport providers and safety notes. |

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,7 +1,19 @@
 """API router assembly for LACOSA."""
 from fastapi import APIRouter
 
-from app.api import concierge, culture, housing, relocation, safety, schools, shopping, transport, users, utilities
+from app.api import (
+    concierge,
+    culture,
+    housing,
+    lifestyle,
+    relocation,
+    safety,
+    schools,
+    shopping,
+    transport,
+    users,
+    utilities,
+)
 
 
 router = APIRouter(prefix="/api")
@@ -11,6 +23,7 @@ router.include_router(safety.router)
 router.include_router(housing.router)
 router.include_router(schools.router)
 router.include_router(shopping.router)
+router.include_router(lifestyle.router)
 router.include_router(culture.router)
 router.include_router(transport.router)
 router.include_router(concierge.router)

--- a/app/api/lifestyle.py
+++ b/app/api/lifestyle.py
@@ -1,0 +1,67 @@
+"""Food, cafés, and nightlife endpoints."""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence
+
+from fastapi import APIRouter, Query
+
+from app.models.base import Venue
+from app.services.data_loader import load_dataset
+
+
+router = APIRouter(prefix="/lifestyle", tags=["lifestyle"])
+
+
+_TAG_LOOKUP: dict[str, Sequence[str]] = {
+    "has_wifi": ("wifi", "wi-fi"),
+    "remote_work_friendly": ("remote work friendly", "remote-work-friendly", "remote-friendly"),
+    "vegetarian_friendly": ("vegetarian friendly", "vegetarian-friendly", "vegetarian options"),
+    "family_friendly": ("family friendly", "family-friendly"),
+}
+
+
+def _normalise_tags(tags: Iterable[str]) -> set[str]:
+    return {tag.lower().replace("-", " ") for tag in tags}
+
+
+def _matches_flag(tags: set[str], flag: Optional[bool], lookup_key: str) -> bool:
+    if flag is None:
+        return True
+    candidates = {item.replace("-", " ") for item in _TAG_LOOKUP[lookup_key]}
+    has_tag = any(candidate in tags for candidate in candidates)
+    return has_tag if flag else not has_tag
+
+
+@router.get("/venues", response_model=List[Venue])
+def list_lifestyle_venues(
+    venue_type: Optional[str] = Query(None, description="Filter by venue type such as cafe or bar."),
+    has_wifi: Optional[bool] = Query(
+        None, description="Filter venues that advertise Wi-Fi availability."
+    ),
+    remote_work_friendly: Optional[bool] = Query(
+        None, description="Filter venues suited for remote work setups."
+    ),
+    vegetarian_friendly: Optional[bool] = Query(
+        None, description="Filter venues with vegetarian-friendly options."
+    ),
+    family_friendly: Optional[bool] = Query(
+        None, description="Filter venues that welcome families with kids."
+    ),
+) -> List[Venue]:
+    """Return curated food, café, and nightlife venues with optional filters."""
+    venues = [Venue(**item) for item in load_dataset("venues")]
+    results: List[Venue] = []
+    for venue in venues:
+        if venue_type and venue.type.lower() != venue_type.lower():
+            continue
+        normalised_tags = _normalise_tags(venue.tags)
+        if not _matches_flag(normalised_tags, has_wifi, "has_wifi"):
+            continue
+        if not _matches_flag(normalised_tags, remote_work_friendly, "remote_work_friendly"):
+            continue
+        if not _matches_flag(normalised_tags, vegetarian_friendly, "vegetarian_friendly"):
+            continue
+        if not _matches_flag(normalised_tags, family_friendly, "family_friendly"):
+            continue
+        results.append(venue)
+    return results

--- a/app/data/venues.json
+++ b/app/data/venues.json
@@ -3,7 +3,7 @@
     "id": "venue-001",
     "name": "Pasticceria Cappello",
     "type": "cafe",
-    "tags": ["wifi", "remote-friendly", "dessert"],
+    "tags": ["wifi", "remote-work-friendly", "dessert", "breakfast"],
     "description": "Family-run bakery with strong Wi-Fi and quiet upstairs seating.",
     "neighborhood": "Porta Nuova",
     "coordinates": {"lat": 38.1137, "lng": 13.3543},
@@ -13,7 +13,7 @@
     "id": "venue-002",
     "name": "Ferro di Cavallo",
     "type": "restaurant",
-    "tags": ["local", "family-friendly"],
+    "tags": ["local", "family-friendly", "vegetarian-friendly"],
     "description": "Classic trattoria welcoming to families, great for first-time visitors.",
     "neighborhood": "La Loggia",
     "coordinates": {"lat": 38.1184, "lng": 13.3621},
@@ -23,9 +23,19 @@
     "id": "venue-003",
     "name": "Nea",
     "type": "bar",
-    "tags": ["cocktails", "expat"],
+    "tags": ["cocktails", "expat", "late-night"],
     "description": "Cocktail bar popular with international community; bilingual staff.",
     "neighborhood": "Kalsa",
     "coordinates": {"lat": 38.1179, "lng": 13.3675}
+  },
+  {
+    "id": "venue-004",
+    "name": "Moltivolti",
+    "type": "restaurant",
+    "tags": ["vegetarian-friendly", "remote-work-friendly", "wifi"],
+    "description": "Social enterprise cafe with coworking tables and Mediterranean menu.",
+    "neighborhood": "Ballarò",
+    "coordinates": {"lat": 38.1109, "lng": 13.3627},
+    "url": "https://maps.google.com/?q=Moltivolti"
   }
 ]

--- a/app/services/concierge.py
+++ b/app/services/concierge.py
@@ -36,7 +36,12 @@ def _search_sections(query: str) -> tuple[str, List[str]]:
 
     # Food venues
     for venue in load_dataset("venues"):
-        if any(tag in query_lower for tag in [t.lower() for t in venue["tags"]]) or venue["name"].lower() in query_lower:
+        tags = [tag.lower() for tag in venue["tags"]]
+        normalised_tags = {tag.replace("-", " ") for tag in tags}
+        if (
+            venue["name"].lower() in query_lower
+            or any(tag in query_lower for tag in normalised_tags)
+        ):
             responses.append(
                 f"{venue['name']} — {venue['description']} (Tags: {', '.join(venue['tags'])})."
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.110.0
 uvicorn==0.29.0
-pydantic==1.10.14
+pydantic==2.7.1
+httpx==0.27.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration to ensure local packages are importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,18 @@ def test_housing_filter() -> None:
     assert all(rental["kid_friendly"] for rental in rentals)
 
 
+def test_lifestyle_remote_work_filter() -> None:
+    response = client.get(
+        "/api/lifestyle/venues", params={"remote_work_friendly": True}
+    )
+    assert response.status_code == 200
+    venues = response.json()
+    assert venues
+    for venue in venues:
+        normalised_tags = {tag.lower().replace("-", " ") for tag in venue["tags"]}
+        assert "remote work friendly" in normalised_tags
+
+
 def test_relocation_pack_fields() -> None:
     response = client.get("/api/relocation/packs")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add a lifestyle router with filterable café and nightlife listings that map to the PRD requirements
- enrich curated venue data and concierge matching to recognise expat-friendly tags
- bump dependencies and add pytest path helper so the FastAPI test client works reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0de451754832ba4b26b87be3abb42