### PR TITLE
Expose map marker endpoints and connect frontend map

### DIFF
--- a/app/api/housing.py
+++ b/app/api/housing.py
@@ -5,11 +5,24 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Query
 
-from app.models.base import RentalListing
+from app.models.base import MapMarker, RentalListing
 from app.services.data_loader import load_dataset
 
 
 router = APIRouter(prefix="/housing", tags=["housing"])
+
+
+HOUSING_MARKERS: list[MapMarker] = [
+    MapMarker(id=1, name="2BR · Kalsa", lat=38.1169, lng=13.3735),
+    MapMarker(id=2, name="Loft · Centro", lat=38.12, lng=13.357),
+]
+
+
+@router.get("", response_model=list[MapMarker])
+def list_housing_markers() -> list[MapMarker]:
+    """Return lightweight housing markers for map overlays."""
+
+    return HOUSING_MARKERS
 
 
 @router.get("/rentals", response_model=List[RentalListing])

--- a/app/api/safety.py
+++ b/app/api/safety.py
@@ -6,11 +6,25 @@ from typing import List, Dict, Any, Optional
 
 from fastapi import APIRouter, Query
 
-from app.models.base import SafetyZone
+from app.models.base import SafetyMarker, SafetyZone
 from app.services.data_loader import load_dataset
 
 
 router = APIRouter(prefix="/safety", tags=["safety"])
+
+
+SAFETY_MARKERS: list[SafetyMarker] = [
+    SafetyMarker(id=1, lat=38.118, lng=13.37, risk="high"),
+    SafetyMarker(id=2, lat=38.125, lng=13.34, risk="medium"),
+    SafetyMarker(id=3, lat=38.105, lng=13.37, risk="low"),
+]
+
+
+@router.get("", response_model=list[SafetyMarker])
+def list_safety_markers() -> list[SafetyMarker]:
+    """Return categorized safety markers for the live map."""
+
+    return SAFETY_MARKERS
 
 
 @router.get("/zones", response_model=List[SafetyZone])

--- a/app/api/schools.py
+++ b/app/api/schools.py
@@ -5,11 +5,24 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Query
 
-from app.models.base import School
+from app.models.base import MapMarker, School
 from app.services.data_loader import load_dataset
 
 
 router = APIRouter(prefix="/schools", tags=["schools"])
+
+
+SCHOOL_MARKERS: list[MapMarker] = [
+    MapMarker(id=1, name="Bilingual Montessori", lat=38.131, lng=13.36),
+    MapMarker(id=2, name="International School", lat=38.104, lng=13.354),
+]
+
+
+@router.get("", response_model=list[MapMarker])
+def list_school_markers() -> list[MapMarker]:
+    """Return map-friendly school markers."""
+
+    return SCHOOL_MARKERS
 
 
 @router.get("/directory", response_model=List[School])

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional, Literal
+from typing import List, Optional, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -10,6 +10,24 @@ from pydantic import BaseModel, Field
 class GeoPoint(BaseModel):
     lat: float = Field(..., description="Latitude coordinate")
     lng: float = Field(..., description="Longitude coordinate")
+
+
+class MapMarker(BaseModel):
+    """Simple marker representation for map overlays."""
+
+    id: Union[str, int]
+    name: str
+    lat: float
+    lng: float
+
+
+class SafetyMarker(BaseModel):
+    """Lightweight safety marker with categorical risk level."""
+
+    id: Union[str, int]
+    lat: float
+    lng: float
+    risk: Literal["low", "medium", "high"]
 
 
 class SafetyZone(BaseModel):

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,7 @@
+export const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8000";
+
+export async function getJSON<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -1,0 +1,106 @@
+import { MapContainer, TileLayer, Marker, Popup, Circle } from "react-leaflet";
+import { useEffect, useMemo, useState } from "react";
+import L from "leaflet";
+import { getJSON } from "../lib/api";
+
+const PALERMO: [number, number] = [38.1157, 13.3613];
+
+type Housing = { id: number; name: string; lat: number; lng: number };
+type School = Housing;
+type Safety = { id: number; lat: number; lng: number; risk: "low" | "medium" | "high" };
+
+export default function Map() {
+  const [showSafety, setShowSafety] = useState(true);
+  const [showHousing, setShowHousing] = useState(true);
+  const [showSchools, setShowSchools] = useState(true);
+  const [housing, setHousing] = useState<Housing[]>([]);
+  const [schools, setSchools] = useState<School[]>([]);
+  const [safety, setSafety] = useState<Safety[]>([]);
+
+  const markerIcon = useMemo(
+    () =>
+      new L.Icon({
+        iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+        iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+        shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+      }),
+    []
+  );
+
+  useEffect(() => {
+    getJSON<Housing[]>("/api/housing").then(setHousing).catch(console.error);
+    getJSON<School[]>("/api/schools").then(setSchools).catch(console.error);
+    getJSON<Safety[]>("/api/safety").then(setSafety).catch(console.error);
+  }, []);
+
+  const riskColor = (r: Safety["risk"]) =>
+    r === "high" ? "#ef4444" : r === "medium" ? "#f59e0b" : "#10b981";
+
+  return (
+    <main className="pb-2">
+      <header className="sticky top-0 z-10 bg-white border-b">
+        <div className="px-4 py-3 flex flex-wrap items-center gap-2">
+          <h1 className="text-base font-semibold mr-auto">Map</h1>
+          <button
+            className={`px-3 py-1.5 text-xs rounded-full border ${
+              showSafety ? "bg-blue-50 border-blue-200 text-blue-700" : "bg-white"
+            }`}
+            onClick={() => setShowSafety((v) => !v)}
+          >
+            Safety
+          </button>
+          <button
+            className={`px-3 py-1.5 text-xs rounded-full border ${
+              showHousing ? "bg-blue-50 border-blue-200 text-blue-700" : "bg-white"
+            }`}
+            onClick={() => setShowHousing((v) => !v)}
+          >
+            Housing
+          </button>
+          <button
+            className={`px-3 py-1.5 text-xs rounded-full border ${
+              showSchools ? "bg-blue-50 border-blue-200 text-blue-700" : "bg-white"
+            }`}
+            onClick={() => setShowSchools((v) => !v)}
+          >
+            Schools
+          </button>
+        </div>
+      </header>
+
+      <div className="p-4">
+        <div className="card overflow-hidden">
+          <MapContainer center={PALERMO} zoom={13} scrollWheelZoom style={{ height: "65vh", width: "100%" }}>
+            <TileLayer attribution="&copy; OpenStreetMap contributors" url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+
+            {showSafety &&
+              safety.map((s) => (
+                <Circle
+                  key={s.id}
+                  center={[s.lat, s.lng]}
+                  radius={400}
+                  pathOptions={{ color: riskColor(s.risk) }}
+                />
+              ))}
+
+            {showHousing &&
+              housing.map((h) => (
+                <Marker key={h.id} position={[h.lat, h.lng]} icon={markerIcon}>
+                  <Popup>{h.name}</Popup>
+                </Marker>
+              ))}
+
+            {showSchools &&
+              schools.map((s) => (
+                <Marker key={s.id} position={[s.lat, s.lng]} icon={markerIcon}>
+                  <Popup>{s.name}</Popup>
+                </Marker>
+              ))}
+          </MapContainer>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add lightweight map marker models and endpoints for housing, schools, and safety
- create shared frontend API helper and map page that loads markers from FastAPI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e110e93270832b93d0af669b7c61d3