### PR TITLE
Add mobile React scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ __pycache__/
 ENV/
 venv/
 .cache/
+# Frontend artifacts
+node_modules/
+**/node_modules/
+*.log
+*.lock
+dist/
+*.tsbuildinfo

--- a/lacosa-mobile/index.html
+++ b/lacosa-mobile/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>LACOSA · Mobile</title>
+  </head>
+  <body class="bg-gray-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/lacosa-mobile/package.json
+++ b/lacosa-mobile/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lacosa-mobile",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5173"
+  },
+  "dependencies": {
+    "lucide-react": "^0.460.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8"
+  }
+}

--- a/lacosa-mobile/postcss.config.js
+++ b/lacosa-mobile/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/lacosa-mobile/src/App.tsx
+++ b/lacosa-mobile/src/App.tsx
@@ -1,0 +1,22 @@
+import { Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import Map from "./pages/Map";
+import Housing from "./pages/Housing";
+import Essentials from "./pages/Essentials";
+import Concierge from "./pages/Concierge";
+import BottomNav from "./components/BottomNav";
+
+export default function App() {
+  return (
+    <div className="min-h-[100svh] pb-20">
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/map" element={<Map />} />
+        <Route path="/housing" element={<Housing />} />
+        <Route path="/essentials" element={<Essentials />} />
+        <Route path="/concierge" element={<Concierge />} />
+      </Routes>
+      <BottomNav />
+    </div>
+  );
+}

--- a/lacosa-mobile/src/components/AlertCard.tsx
+++ b/lacosa-mobile/src/components/AlertCard.tsx
@@ -1,0 +1,23 @@
+export type Alert = {
+  kind: "Strike" | "Event" | "Safety";
+  title: string;
+  time: string;
+};
+
+const kindStyles: Record<Alert["kind"], string> = {
+  Strike: "bg-amber-100 text-amber-800",
+  Event: "bg-emerald-100 text-emerald-800",
+  Safety: "bg-rose-100 text-rose-800",
+};
+
+export function AlertCard({ a }: { a: Alert }) {
+  return (
+    <div className="card p-3">
+      <span className={`px-2 py-0.5 rounded text-xs ${kindStyles[a.kind]}`}>
+        {a.kind}
+      </span>
+      <h3 className="mt-2 text-sm font-medium">{a.title}</h3>
+      <p className="mt-1 text-xs text-gray-500">{a.time}</p>
+    </div>
+  );
+}

--- a/lacosa-mobile/src/components/BottomNav.tsx
+++ b/lacosa-mobile/src/components/BottomNav.tsx
@@ -1,0 +1,43 @@
+import { NavLink } from "react-router-dom";
+import {
+  Home,
+  Map as MapIcon,
+  Building2,
+  Package,
+  MessageCircle,
+} from "lucide-react";
+
+const items = [
+  { to: "/", icon: Home, label: "Home" },
+  { to: "/map", icon: MapIcon, label: "Map" },
+  { to: "/housing", icon: Building2, label: "Housing" },
+  { to: "/essentials", icon: Package, label: "Essentials" },
+  { to: "/concierge", icon: MessageCircle, label: "Chat" },
+];
+
+export default function BottomNav() {
+  return (
+    <nav
+      className="fixed bottom-0 inset-x-0 z-50 bg-white/95 backdrop-blur border-t"
+      style={{ paddingBottom: "max(0px, var(--safe-bottom))" }}
+    >
+      <ul className="grid grid-cols-5">
+        {items.map(({ to, icon: Icon, label }) => (
+          <li key={to}>
+            <NavLink
+              to={to}
+              className={({ isActive }) =>
+                `flex flex-col items-center justify-center py-2 text-xs ${
+                  isActive ? "text-blue-600" : "text-gray-600"
+                }`
+              }
+            >
+              <Icon size={22} />
+              <span className="mt-0.5">{label}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/lacosa-mobile/src/index.css
+++ b/lacosa-mobile/src/index.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* iOS safe area for bottom nav */
+:root {
+  --safe-bottom: env(safe-area-inset-bottom);
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Helpful utilities */
+.card {
+  @apply rounded-xl border bg-white shadow-sm;
+}
+.section {
+  @apply p-4;
+}

--- a/lacosa-mobile/src/main.tsx
+++ b/lacosa-mobile/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/lacosa-mobile/src/pages/Concierge.tsx
+++ b/lacosa-mobile/src/pages/Concierge.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+export default function Concierge() {
+  const [text, setText] = useState("");
+  const suggestions = [
+    "Find bilingual Montessori",
+    "Best area for 2BR under €1.2k",
+    "How to get permesso di soggiorno?",
+    "Safest route from airport tonight",
+  ];
+
+  return (
+    <main className="section pb-2">
+      <h1 className="text-base font-semibold mb-3">Concierge</h1>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        {suggestions.map((s) => (
+          <button
+            key={s}
+            onClick={() => setText(s)}
+            className="text-xs px-3 py-1.5 rounded-full border bg-white"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+
+      <div className="card p-3">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={4}
+          placeholder="Ask anything about Palermo…"
+          className="w-full text-sm outline-none resize-none"
+        />
+        <div className="mt-2 flex justify-end">
+          <button className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white">
+            Send
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-3 text-xs text-gray-500">
+        (Wire this to your AI endpoint later)
+      </p>
+    </main>
+  );
+}

--- a/lacosa-mobile/src/pages/Essentials.tsx
+++ b/lacosa-mobile/src/pages/Essentials.tsx
@@ -1,0 +1,49 @@
+type Item = { name: string; kind: string; meta: string };
+
+const groups: Record<string, Item[]> = {
+  Health: [
+    { name: "Farmacia Internazionale", kind: "Pharmacy", meta: "24h · EN speaking" },
+    { name: "Clinic Centro", kind: "Clinic", meta: "Walk-in" },
+  ],
+  Schools: [
+    { name: "Bilingual Montessori", kind: "Early Education", meta: "EN/IT" },
+    { name: "International School", kind: "Primary–HS", meta: "Admissions Feb" },
+  ],
+  Transport: [
+    { name: "AMAT Tram T1", kind: "Tram", meta: "Every 7–10 min" },
+    { name: "Taxi Palermo", kind: "Taxi", meta: "WhatsApp booking" },
+  ],
+};
+
+export default function Essentials() {
+  const tabs = Object.keys(groups);
+  return (
+    <main className="section">
+      <h1 className="text-base font-semibold mb-2">Essentials</h1>
+      <div className="mb-3 flex gap-2">
+        {tabs.map((t) => (
+          <button key={t} className="px-3 py-1.5 text-xs rounded-full border bg-white">
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-2">
+        {tabs.map((t) => (
+          <section key={t}>
+            <h2 className="text-xs font-semibold text-gray-600 mb-1">{t}</h2>
+            <div className="grid gap-2">
+              {groups[t].map((it, i) => (
+                <div key={i} className="card p-3">
+                  <div className="text-sm font-medium">{it.name}</div>
+                  <div className="text-xs text-gray-600">{it.kind}</div>
+                  <div className="text-xs text-gray-500">{it.meta}</div>
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/lacosa-mobile/src/pages/Home.tsx
+++ b/lacosa-mobile/src/pages/Home.tsx
@@ -1,0 +1,67 @@
+import { AlertCard, type Alert } from "../components/AlertCard";
+
+export default function Home() {
+  const alerts: Alert[] = [
+    { kind: "Strike", title: "AMAT bus strike Fri 08:00–12:00", time: "22 May · 09:00" },
+    { kind: "Event", title: "Protest at Piazza Pretoria Sat 17:00", time: "17 May · 09:00" },
+    { kind: "Safety", title: "Pickpocketing watch at Ballarò market", time: "18 May · 21:10" },
+  ];
+
+  const quick = [
+    "Find school",
+    "Rent near Kalsa",
+    "24h Pharmacy",
+    "Airport transit",
+    "SIM & internet",
+    "Talk to concierge",
+  ];
+
+  return (
+    <main className="pb-4">
+      <header className="px-4 pt-4 pb-3 bg-gradient-to-b from-blue-600 to-blue-500 text-white">
+        <div className="flex items-center gap-2">
+          <h1 className="text-lg font-semibold">LACOSA</h1>
+          <span className="ml-auto text-sm bg-white/20 rounded px-2 py-1">Palermo ▾</span>
+        </div>
+        <p className="text-xs opacity-90 mt-1">Live alerts, housing, schools & essentials</p>
+      </header>
+
+      <section className="section grid gap-3">
+        {alerts.map((a, i) => (
+          <AlertCard key={i} a={a} />
+        ))}
+      </section>
+
+      <section className="section">
+        <h2 className="text-sm font-semibold mb-2">Quick actions</h2>
+        <div className="grid grid-cols-3 gap-2">
+          {quick.map((q) => (
+            <button
+              key={q}
+              className="text-xs px-3 py-2 rounded-lg border bg-white"
+            >
+              {q}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="section">
+        <h2 className="text-sm font-semibold mb-2">Housing spotlight</h2>
+        <div className="flex gap-3 overflow-x-auto snap-x">
+          {[1, 2, 3].map((n) => (
+            <article key={n} className="min-w-[260px] snap-start card overflow-hidden">
+              <div className="h-28 bg-gray-200" />
+              <div className="p-3">
+                <h3 className="text-sm font-medium">2BR near Teatro Massimo</h3>
+                <p className="text-xs text-gray-600">€1,150/mo · 350m to tram</p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <div className="h-6" />
+    </main>
+  );
+}

--- a/lacosa-mobile/src/pages/Housing.tsx
+++ b/lacosa-mobile/src/pages/Housing.tsx
@@ -1,0 +1,44 @@
+type House = { title: string; area: string; price: string; distance: string; img?: string };
+
+const data: House[] = [
+  { title: "2BR · Kalsa", area: "Kalsa", price: "€1,100/mo", distance: "300m to tram" },
+  { title: "Loft near Teatro", area: "Centro", price: "€950/mo", distance: "500m to bus" },
+  { title: "Family 3BR", area: "Mondello", price: "€1,600/mo", distance: "Near beach" },
+];
+
+export default function Housing() {
+  return (
+    <main>
+      <header className="sticky top-0 z-10 bg-white border-b">
+        <div className="px-4 py-3 flex gap-2 overflow-x-auto">
+          {["Price", "Beds", "Neighborhood", "Furnished", "Family-friendly"].map((f) => (
+            <button key={f} className="px-3 py-1.5 text-xs rounded-full border bg-white">
+              {f}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <section>
+        {data.map((h, i) => (
+          <div key={i} className="flex gap-3 p-3 border-b bg-white">
+            <div className="w-24 h-24 bg-gray-200 rounded-lg" />
+            <div className="min-w-0">
+              <h3 className="text-sm font-medium truncate">{h.title}</h3>
+              <p className="text-xs text-gray-600">
+                {h.area} · {h.price}
+              </p>
+              <p className="text-xs text-gray-500">{h.distance}</p>
+              <div className="mt-2 flex gap-2">
+                <button className="text-xs px-2 py-1 rounded bg-blue-600 text-white">
+                  Contact
+                </button>
+                <button className="text-xs px-2 py-1 rounded border">Save</button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/lacosa-mobile/src/pages/Map.tsx
+++ b/lacosa-mobile/src/pages/Map.tsx
@@ -1,0 +1,13 @@
+export default function Map() {
+  return (
+    <main className="section">
+      <h1 className="text-base font-semibold mb-2">Map</h1>
+      <div className="card h-[60vh] flex items-center justify-center text-gray-500">
+        (Map placeholder) • Add react-leaflet or Google Maps here
+      </div>
+      <p className="mt-3 text-xs text-gray-600">
+        Toggle layers: Safety / Housing / Schools / Essentials
+      </p>
+    </main>
+  );
+}

--- a/lacosa-mobile/tailwind.config.js
+++ b/lacosa-mobile/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/lacosa-mobile/tsconfig.json
+++ b/lacosa-mobile/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/lacosa-mobile/tsconfig.node.json
+++ b/lacosa-mobile/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/lacosa-mobile/vite.config.ts
+++ b/lacosa-mobile/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- add a Vite + React mobile scaffold with routing, Tailwind, and lucide icons
- implement bottom tab navigation and placeholder pages for core app sections
- include reusable alert card component and Tailwind utility styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10c555740832b8986efdece8ab7dd